### PR TITLE
WIP Bully algorithm implementation

### DIFF
--- a/server-node/src/config.rs
+++ b/server-node/src/config.rs
@@ -8,11 +8,13 @@
 use serde::Deserialize;
 use std::{error::Error, ffi::OsStr, net::SocketAddr, path::Path, str::FromStr, time::Duration};
 
+use crate::peer::PeerId;
+
 #[derive(Deserialize, Debug)]
 struct ConfigFile {
     address_private: SocketAddr,
     peers: Vec<SocketAddr>,
-    id: u32,
+    id: PeerId,
     heartbeat_timeout: u64,
     // TODO DHCP interface?
 }
@@ -32,7 +34,7 @@ impl FromStr for ConfigFile {
 pub struct Config {
     pub address_private: SocketAddr,
     pub peers: Vec<SocketAddr>,
-    pub id: u32,
+    pub id: PeerId,
     pub heartbeat_timeout: Duration,
 }
 

--- a/server-node/src/message.rs
+++ b/server-node/src/message.rs
@@ -6,7 +6,7 @@
 //!
 //! Jump to [`Message`] for the server-to-server message definition.
 
-use crate::Lease;
+use crate::{peer::PeerId, Lease};
 use serde::{Deserialize, Serialize};
 use std::{
     io::{self},
@@ -17,8 +17,8 @@ use std::{
 /// # A server-to-server message
 #[derive(Serialize, Deserialize, Debug, PartialEq)]
 pub enum Message {
-    Join(u32),
-    JoinAck(u32),
+    Join(PeerId),
+    JoinAck(PeerId),
     Heartbeat,
     Election,
     Okay,

--- a/server-node/src/peer.rs
+++ b/server-node/src/peer.rs
@@ -14,10 +14,12 @@ enum SenderThreadMessage {
     Relay(Message),
 }
 
+pub type PeerId = u32;
+
 /// Peer connection
 #[allow(dead_code)]
 pub struct Peer {
-    pub id: u32,
+    pub id: PeerId,
     tx: Sender<SenderThreadMessage>,
     read_thread: JoinHandle<()>,
     write_thread: JoinHandle<()>,
@@ -26,7 +28,7 @@ pub struct Peer {
 impl Peer {
     pub fn new(
         stream: TcpStream,
-        id: u32,
+        id: PeerId,
         server_tx: Sender<ServerThreadMessage>,
         heartbeat_timeout: Duration,
     ) -> Self {
@@ -60,7 +62,7 @@ impl Peer {
 
     fn read_thread_fn(
         stream: TcpStream,
-        peer_id: u32,
+        peer_id: PeerId,
         tx: Sender<SenderThreadMessage>,
         server_tx: Sender<ServerThreadMessage>,
     ) {
@@ -87,7 +89,10 @@ impl Peer {
                 }
                 Heartbeat => println!("Received heartbeat from {peer_id}"),
                 _ => server_tx
-                    .send(ServerThreadMessage::ProtocolMessage(message))
+                    .send(ServerThreadMessage::ProtocolMessage {
+                        sender_id: peer_id,
+                        message,
+                    })
                     .unwrap(),
             }
         }


### PR DESCRIPTION
I was testing editor features, but oops, I added some parts of the elections until most of it was in place.

Anyway, the main issue with this code is that a node waiting for an election to time out won't consider cluster changes (especially new peer handshakes), and may send a Coordinator to a node with higher id.

One solution is to restart election if peers changed, or to make the server code react to Coordinator messages in a smart way.